### PR TITLE
remove stray DSAuth import

### DIFF
--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.6;
 
-import { DSAuthority, DSAuth } from "ds-auth/auth.sol";
 import "ds-note/note.sol";
 
 contract GemLike {


### PR DESCRIPTION
Even though the submodule has been removed, DSAuth is an indirect
dependency via DSToken, therefore the import wasn't failing.