### PR TITLE
ESMom

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/ds-token"]
 	path = lib/ds-token
 	url = https://github.com/dapphub/ds-token
+[submodule "lib/dss"]
+	path = lib/dss
+	url = https://github.com/makerdao/dss

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -1,3 +1,18 @@
+// Copyright (C) 2019 Maker Ecosystem Growth Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.5.6;
 
 import "ds-note/note.sol";

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -51,6 +51,7 @@ contract ESM is DSNote {
         require(z <= x);
     }
 
+
     // -- admin --
     function file(bytes32 job, address obj) external auth note {
         if (job == "end") end = EndLike(obj);
@@ -61,7 +62,7 @@ contract ESM is DSNote {
         if (job == "cap") cap = val;
     }
 
-    // -- state changes --
+    // -- unauthed state changes --
     function fire() external note {
         require(state == START && full(), "esm/not-fireable");
 
@@ -70,6 +71,7 @@ contract ESM is DSNote {
         state = FIRED;
     }
 
+    // -- authed state changes --
     function free() external auth note {
         require(state == START || state == FIRED, "esm/not-freeable");
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -51,17 +51,6 @@ contract ESM is DSNote {
         require(z <= x);
     }
 
-
-    // -- admin --
-    function file(bytes32 job, address obj) external auth note {
-        if (job == "end") end = EndLike(obj);
-        if (job == "sun") sun = obj;
-    }
-
-    function file(bytes32 job, uint256 val) external auth note {
-        if (job == "cap") cap = val;
-    }
-
     // -- unauthed state changes --
     function fire() external note {
         require(state == START && full(), "esm/not-fireable");

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -27,13 +27,11 @@ contract ESM is DSNote {
     uint256 public constant FIRED = 3;
     uint256 public          state = START;
 
-    mapping(address => uint256) public wards;
-    function rely(address usr) public auth note { wards[usr] = 1; }
-    function deny(address usr) public auth note { wards[usr] = 0; }
-    modifier auth() { require(wards[msg.sender] == 1, "esm/unauthorized"); _; }
+    address public owner;
+    modifier auth() { require(msg.sender == owner, "esm/unauthorized"); _; }
 
-    constructor(address ward, address gem_, address end_, address sun_, uint256 cap_) public {
-        wards[ward] = 1;
+    constructor(address owner_, address gem_, address end_, address sun_, uint256 cap_) public {
+        owner = owner_;
 
         gem = GemLike(gem_);
         end = EndLike(end_);

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -59,7 +59,7 @@ contract ESMTest is DSTest {
     }
 
     function test_constructor() public {
-        assertEq(esm.wards(address(gov)), 1);
+        assertEq(esm.owner(), address(gov));
         assertEq(address(esm.gem()), address(gem));
         assertEq(address(esm.end()), address(end));
         assertEq(esm.sun(), address(0x1));
@@ -258,13 +258,6 @@ contract ESMTest is DSTest {
     }
 
     // -- auth --
-    function testFail_unauthorized_rely() public {
-        esm.rely(address(0x0));
-    }
-    function testFail_unauthorized_deny() public {
-        esm.deny(address(0x0));
-    }
-
     function testFail_unauthorized_free() public {
         esm.free();
     }

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -1,3 +1,18 @@
+// Copyright (C) 2019 Maker Ecosystem Growth Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.5.6;
 
 import "ds-test/test.sol";

--- a/src/ESMom.sol
+++ b/src/ESMom.sol
@@ -1,3 +1,18 @@
+// Copyright (C) 2019 Maker Ecosystem Growth Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.5.6;
 
 import {ESM} from "./ESM.sol";

--- a/src/ESMom.sol
+++ b/src/ESMom.sol
@@ -16,6 +16,8 @@ contract ESMom is DSNote {
     address public sun;
     uint256 public cap;
 
+    mapping(address => uint256) public old;
+
     mapping(address => uint256) public wards;
     function rely(address usr) public auth note { wards[usr] = 1; }
     function deny(address usr) public auth note { wards[usr] = 0; }
@@ -41,11 +43,20 @@ contract ESMom is DSNote {
     }
 
     // -- actions --
-    function free() external auth note { esm.free(); }
-    function burn() external auth note { esm.burn(); }
+    function free(address esm_) external auth note {
+        require(old[esm_] == 1, "esmom/not-an-old-esm");
+
+        ESM(esm_).free();
+    }
+    function burn(address esm_) external auth note {
+        require(old[esm_] == 1, "esmom/not-an-old-esm");
+
+        ESM(esm_).burn();
+    }
 
     function swap() external auth note returns (address) {
         end.deny(address(esm));
+        old[address(esm)] = 1;
 
         esm = new ESM(address(this), gem, address(end), sun, cap);
         end.rely(address(esm));

--- a/src/ESMom.sol
+++ b/src/ESMom.sol
@@ -44,7 +44,7 @@ contract ESMom is DSNote {
     function free() external auth note { esm.free(); }
     function burn() external auth note { esm.burn(); }
 
-    function replace() external auth note returns (address) {
+    function swap() external auth note returns (address) {
         end.deny(address(esm));
 
         esm = new ESM(address(this), gem, address(end), sun, cap);

--- a/src/ESMom.sol
+++ b/src/ESMom.sol
@@ -41,28 +41,15 @@ contract ESMom is DSNote {
     }
 
     // -- actions --
-    function free() external auth note returns (address) {
-        esm.free();
+    function free() external auth note { esm.free(); }
+    function burn() external auth note { esm.burn(); }
 
-        replace();
-
-        return address(esm);
-    }
-
-    function burn() external auth note returns (address) {
-        esm.burn();
-
-        replace();
-
-        return address(esm);
-    }
-
-    // -- helpers --
-    function replace() internal {
+    function replace() external auth note returns (address) {
         end.deny(address(esm));
 
         esm = new ESM(address(this), gem, address(end), sun, cap);
-
         end.rely(address(esm));
+
+        return address(esm);
     }
 }

--- a/src/ESMom.sol
+++ b/src/ESMom.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.5.6;
+
+import {ESM} from "./ESM.sol";
+
+import {DSNote} from "ds-note/note.sol";
+
+contract EndLike {
+    function rely(address) public;
+    function deny(address) public;
+}
+
+contract ESMom is DSNote {
+    ESM     public esm;
+    address public gem;
+    EndLike public end;
+    address public sun;
+    uint256 public cap;
+
+    mapping(address => uint256) public wards;
+    function rely(address usr) public auth note { wards[usr] = 1; }
+    function deny(address usr) public auth note { wards[usr] = 0; }
+    modifier auth() { require(wards[msg.sender] == 1, "esmom/unauthorized"); _; }
+
+    constructor(address ward, address gem_, address end_, address sun_, uint256 cap_) public {
+        wards[ward] = 1;
+        gem = gem_;
+        end = EndLike(end_);
+        sun = sun_;
+        cap = cap_;
+
+        esm = new ESM(address(this), gem_, end_, sun_, cap_);
+    }
+
+    function file(bytes32 job, address obj) external auth note {
+        if (job == "end") end = EndLike(obj);
+        if (job == "sun") sun = obj;
+    }
+
+    function file(bytes32 job, uint256 val) external auth note {
+        if (job == "cap") cap = val;
+    }
+
+    // -- actions --
+    function free() external auth note returns (address) {
+        esm.free();
+
+        replace();
+
+        return address(esm);
+    }
+
+    function burn() external auth note returns (address) {
+        esm.burn();
+
+        replace();
+
+        return address(esm);
+    }
+
+    // -- helpers --
+    function replace() internal {
+        end.deny(address(esm));
+
+        esm = new ESM(address(this), gem, address(end), sun, cap);
+
+        end.rely(address(esm));
+    }
+}

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -73,9 +73,9 @@ contract ESMomTest is DSTest {
         assertTrue(esm.state() == esm.BURNT());
     }
 
-    function test_replace() public {
+    function test_swap() public {
         address prev = address(mom.esm());
-        address post = mom.replace();
+        address post = mom.swap();
 
         assertTrue(prev != post);
         assertEq(post, address(mom.esm()));

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -1,3 +1,18 @@
+// Copyright (C) 2019 Maker Ecosystem Growth Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 pragma solidity ^0.5.6;
 
 import {ESM} from "./ESM.sol";

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -83,12 +83,30 @@ contract ESMomTest is DSTest {
         assertTrue(esm.state() == esm.FREED());
     }
 
+    function test_free_old_esm() public {
+        ESM old = mom.esm();
+        mom.swap();
+
+        mom.free(address(old));
+
+        assertTrue(old.state() == old.FREED());
+    }
+
     function test_burn() public {
         ESM esm = mom.esm();
         mom.swap();
         mom.burn(address(esm));
 
         assertTrue(esm.state() == esm.BURNT());
+    }
+
+    function test_burn_old_esm() public {
+        ESM old = mom.esm();
+        mom.swap();
+
+        mom.burn(address(old));
+
+        assertTrue(old.state() == old.BURNT());
     }
 
     function test_swap() public {

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -43,6 +43,21 @@ contract ESMomTest is DSTest {
         assertTrue(mom.cap() == 0x42);
     }
 
+    function testFail_unauthorized_file_end() public {
+        mom = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+        mom.file("end", address(0x42));
+    }
+
+    function testFail_unauthorized_file_sun() public {
+        mom = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+        mom.file("sun", address(0x42));
+    }
+
+    function testFail_unauthorized_file_cap() public {
+        mom = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+        mom.file("cap", 0x42);
+    }
+
     // -- actions --
     function test_free() public {
         ESM     prev = mom.esm();

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -61,14 +61,17 @@ contract ESMomTest is DSTest {
     // -- actions --
     function test_free() public {
         ESM esm = mom.esm();
-        mom.free();
+        mom.swap();
+
+        mom.free(address(esm));
 
         assertTrue(esm.state() == esm.FREED());
     }
 
     function test_burn() public {
         ESM esm = mom.esm();
-        mom.burn();
+        mom.swap();
+        mom.burn(address(esm));
 
         assertTrue(esm.state() == esm.BURNT());
     }
@@ -83,16 +86,38 @@ contract ESMomTest is DSTest {
         assertEq(end.wards(post), 1);
     }
 
+    function testFail_free_unknown_esm() public {
+        mom.swap();
+        mom.free(address(0x0));
+    }
+
+    function testFail_burn_unknown_esm() public {
+        mom.swap();
+        mom.burn(address(0x0));
+    }
+
+    function testFail_free_current_esm() public {
+        mom.free(address(mom.esm()));
+    }
+
+    function testFail_burn_current_esm() public {
+        mom.burn(address(mom.esm()));
+    }
+
     function testFail_unauthorized_free() public {
         ESMom mum = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+        ESM esm = mum.esm();
 
-        mum.free();
+        mom.swap();
+        mum.free(address(esm));
     }
 
     function testFail_unauthorized_burn() public {
         ESMom mum = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+        ESM esm = mum.esm();
 
-        mum.burn();
+        mom.swap();
+        mum.burn(address(esm));
     }
 
     function testFail_unauthorized_swap() public {

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -1,0 +1,77 @@
+pragma solidity ^0.5.6;
+
+import {ESM} from "./ESM.sol";
+import {ESMom} from "./ESMom.sol";
+
+import {DSToken} from "ds-token/token.sol";
+import {End} from "dss/end.sol";
+
+import "ds-test/test.sol";
+
+contract ESMomTest is DSTest {
+    ESMom   mom;
+    DSToken gem;
+    End     end;
+    address sun;
+
+    function setUp() public {
+        gem = new DSToken("GOLD");
+        end = new End();
+        sun = address(0x1);
+
+        mom = new ESMom(address(this), address(gem), address(end), address(sun), 10);
+        end.rely(address(mom));
+    }
+
+    function test_constructor() public {
+        assertEq(mom.wards(address(this)), 1);
+        assert(address(mom.esm) != address(0));
+    }
+
+    // -- admin --
+    function test_file() public {
+        assertTrue(address(mom.end()) != address(0x42));
+        mom.file("end", address(0x42));
+        assertTrue(address(mom.end()) == address(0x42));
+
+        assertTrue(address(mom.sun()) != address(0x42));
+        mom.file("sun", address(0x42));
+        assertTrue(address(mom.sun()) == address(0x42));
+
+        assertTrue(mom.cap() != 0x42);
+        mom.file("cap", 0x42);
+        assertTrue(mom.cap() == 0x42);
+    }
+
+    // -- actions --
+    function test_free() public {
+        ESM     prev = mom.esm();
+        address post = mom.free();
+
+        assertTrue(address(prev) != post);
+        assertTrue(prev.state()  == prev.FREED());
+        assertEq(post, address(mom.esm()));
+    }
+
+    function test_burn() public {
+        ESM     prev = mom.esm();
+        address post = mom.burn();
+
+        assertTrue(address(prev) != post);
+        assertTrue(prev.state()  == prev.BURNT());
+        assertEq(post, address(mom.esm()));
+    }
+
+    function testFail_unauthorized_free() public {
+        ESMom mum = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+
+        mum.free();
+    }
+
+    function testFail_unauthorized_burn() public {
+        ESMom mum = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+
+        mum.burn();
+    }
+
+}

--- a/src/ESMom.t.sol
+++ b/src/ESMom.t.sol
@@ -60,21 +60,27 @@ contract ESMomTest is DSTest {
 
     // -- actions --
     function test_free() public {
-        ESM     prev = mom.esm();
-        address post = mom.free();
+        ESM esm = mom.esm();
+        mom.free();
 
-        assertTrue(address(prev) != post);
-        assertTrue(prev.state()  == prev.FREED());
-        assertEq(post, address(mom.esm()));
+        assertTrue(esm.state() == esm.FREED());
     }
 
     function test_burn() public {
-        ESM     prev = mom.esm();
-        address post = mom.burn();
+        ESM esm = mom.esm();
+        mom.burn();
 
-        assertTrue(address(prev) != post);
-        assertTrue(prev.state()  == prev.BURNT());
+        assertTrue(esm.state() == esm.BURNT());
+    }
+
+    function test_replace() public {
+        address prev = address(mom.esm());
+        address post = mom.replace();
+
+        assertTrue(prev != post);
         assertEq(post, address(mom.esm()));
+        assertEq(end.wards(prev), 0);
+        assertEq(end.wards(post), 1);
     }
 
     function testFail_unauthorized_free() public {
@@ -89,4 +95,9 @@ contract ESMomTest is DSTest {
         mum.burn();
     }
 
+    function testFail_unauthorized_swap() public {
+        ESMom mum = new ESMom(address(0x0), address(gem), address(end), address(sun), 10);
+
+        mum.swap();
+    }
 }


### PR DESCRIPTION
Adds an ESMom, which is the governance interface to the ESM.

It can:

* replace an ESM (`swap`)
* call `free` and `burn` on an ESM

`fire` remains callable directly on the ESM by anyone.