### PR TITLE
change type of fired from bool to uint256

### DIFF
--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -17,7 +17,7 @@ contract ESM is DSNote {
     EndLike public end; // cage module
     address public pit; // burner
     uint256 public min; // threshold
-    bool    public fired;
+    uint256 public fired;
 
     mapping(address => uint256) public sum; // per-address balance
     uint256 public Sum; // total balance
@@ -36,16 +36,16 @@ contract ESM is DSNote {
     }
 
     function fire() external note {
-        require(!fired,  "esm/already-fired");
+        require(fired == 0, "esm/already-fired");
         require(full(),  "esm/min-not-reached");
 
         end.cage();
 
-        fired = true;
+        fired = 1;
     }
 
     function join(uint256 wad) external note {
-        require(!fired, "esm/already-fired");
+        require(fired == 0, "esm/already-fired");
 
         sum[msg.sender] = add(sum[msg.sender], wad);
         Sum = add(Sum, wad);

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -52,14 +52,14 @@ contract ESMTest is DSTest {
         assertEq(address(esm.gem()), address(gem));
         assertEq(address(esm.end()), address(end));
         assertEq(esm.min(), 10);
-        assertTrue(!esm.fired());
+        assertEq(esm.fired(), 0);
     }
 
     function test_fire() public {
         esm = makeWithCap(0);
         gov.callFire(esm);
 
-        assertTrue(esm.fired());
+        assertEq(esm.fired(), 1);
         assertEq(end.live(), 0);
     }
 


### PR DESCRIPTION
Makes FV in klab easier, as `bool`s would require tedious/complex lemmas.