### PR TITLE
implement note modifier locally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
-[submodule "lib/ds-note"]
-	path = lib/ds-note
-	url = https://github.com/dapphub/ds-note
 [submodule "lib/ds-token"]
 	path = lib/ds-token
 	url = https://github.com/dapphub/ds-token


### PR DESCRIPTION
The dapphub/ds-note implementation emits all of the calldata passed into
it, which makes formal verification harder, since we need to make
assumptions on the actual calldata in order to avoid an explosion in
complexity.

The implementation has been copied from https://github.com/makerdao/dss/blob/b99ffaeec329b544b7a5d8001daa35100851b1b4/src/vat.sol#L58-L84