### PR TITLE
make full() internal

### DIFF
--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -54,7 +54,7 @@ contract ESM is DSNote {
     }
 
     // -- helpers --
-    function full() public view returns (bool) {
+    function full() internal view returns (bool) {
         return Sum >= min;
     }
 }

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -37,7 +37,7 @@ contract ESM is DSNote {
 
     function fire() external note {
         require(fired == 0, "esm/already-fired");
-        require(full(),  "esm/min-not-reached");
+        require(Sum >= min,  "esm/min-not-reached");
 
         end.cage();
 
@@ -51,10 +51,5 @@ contract ESM is DSNote {
         Sum = add(Sum, wad);
 
         require(gem.transferFrom(msg.sender, pit, wad), "esm/transfer-failed");
-    }
-
-    // -- helpers --
-    function full() internal view returns (bool) {
-        return Sum >= min;
     }
 }

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -55,6 +55,13 @@ contract ESMTest is DSTest {
         assertEq(esm.fired(), 0);
     }
 
+    function test_Sum_is_internal_balance() public {
+        esm = makeWithCap(10);
+        gem.mint(address(esm), 10);
+
+        assertEq(esm.Sum(), 0);
+    }
+
     function test_fire() public {
         esm = makeWithCap(0);
         gov.callFire(esm);
@@ -79,6 +86,7 @@ contract ESMTest is DSTest {
     }
 
     function testFail_fire_min_not_met() public {
+        esm = makeWithCap(10);
         assertTrue(esm.Sum() <= esm.min());
 
         gov.callFire(esm);
@@ -109,28 +117,6 @@ contract ESMTest is DSTest {
         assertEq(gem.balanceOf(address(usr)), 0);
 
         usr.callJoin(esm, 10);
-    }
-
-    // -- helpers --
-    function test_full() public {
-        esm = makeWithCap(10);
-
-        assertTrue(esm.Sum() <= esm.min());
-        gem.mint(address(usr), 10);
-
-        usr.callJoin(esm, 5);
-        assertTrue(esm.Sum() <= esm.min());
-
-        usr.callJoin(esm, 5);
-        assertTrue(esm.Sum() >= esm.min());
-    }
-
-    function test_full_keeps_internal_balance() public {
-        esm = makeWithCap(10);
-        gem.mint(address(esm), 10);
-
-        assertEq(esm.Sum(), 0);
-        assertTrue(esm.Sum() <= esm.min());
     }
 
     // -- internal test helpers --

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -79,7 +79,7 @@ contract ESMTest is DSTest {
     }
 
     function testFail_fire_min_not_met() public {
-        assertTrue(!esm.full());
+        assertTrue(esm.Sum() <= esm.min());
 
         gov.callFire(esm);
     }
@@ -115,14 +115,14 @@ contract ESMTest is DSTest {
     function test_full() public {
         esm = makeWithCap(10);
 
-        assertTrue(!esm.full());
+        assertTrue(esm.Sum() <= esm.min());
         gem.mint(address(usr), 10);
 
         usr.callJoin(esm, 5);
-        assertTrue(!esm.full());
+        assertTrue(esm.Sum() <= esm.min());
 
         usr.callJoin(esm, 5);
-        assertTrue(esm.full());
+        assertTrue(esm.Sum() >= esm.min());
     }
 
     function test_full_keeps_internal_balance() public {
@@ -130,7 +130,7 @@ contract ESMTest is DSTest {
         gem.mint(address(esm), 10);
 
         assertEq(esm.Sum(), 0);
-        assertTrue(!esm.full());
+        assertTrue(esm.Sum() <= esm.min());
     }
 
     // -- internal test helpers --


### PR DESCRIPTION
This change makes reasoning about the entrypoints into the function
easier: there is only one, and it's via jumps.

For such a small function this might not be a big concern, but it's good
practice anyway.