### PR TITLE
Add arbitrary deny support

### DIFF
--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -32,7 +32,7 @@ interface EndLike {
     function cage() external;
 }
 
-interface VatLike {
+interface DenyLike {
     function deny(address) external;
 }
 
@@ -70,10 +70,16 @@ contract ESM {
 
         end.cage();
         if (proxy != address(0)) {
-            VatLike(end.vat()).deny(proxy);
+            DenyLike(end.vat()).deny(proxy);
         }
 
         emit Fire();
+    }
+
+    function deny(address target) external {
+        require(Sum >= min,  "ESM/min-not-reached");
+
+        DenyLike(target).deny(proxy);
     }
 
     function join(uint256 wad) external {

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -201,6 +201,7 @@ contract ESMTest is DSTest {
 
     function testFail_deny_insufficient_mkr() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10);
+        vat.rely(address(esm));
         usr.callDeny(esm, address(vat));
     }
 


### PR DESCRIPTION
This will allow any contract which has authed the esm module to later deny the pause proxy in the event of a governance attack. This will be useful for future modules which require protection from governance in the event of an emergency shutdown.