### PR TITLE
add the ability for non-revoked gov to file a new min

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,9 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2019 Maker Ecosystem Growth Holdings, INC.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
                             Preamble
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -38,6 +38,9 @@ interface DenyLike {
 }
 
 contract ESM {
+    
+    uint256 constant WAD = 10 ** 18;
+
     GemLike public immutable gem;   // collateral (MKR token)
     address public immutable proxy; // Pause proxy
 
@@ -94,7 +97,7 @@ contract ESM {
     // -- admin --
     function file(bytes32 what, uint256 data) external auth {
         if (what == "min") {
-            require(data > 0, "ESM/min-required");
+            require(data > WAD, "ESM/min-too-small");
             min = data;
         } else {
             revert("ESM/file-unrecognized-param");

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -40,13 +40,14 @@ contract ESM {
     GemLike public immutable gem;   // collateral (MKR token)
     EndLike public immutable end;   // cage module
     address public immutable proxy; // Pause proxy
-    uint256 public immutable min;   // minimum activation threshold [wad]
 
     mapping(address => uint256) public sum; // per-address balance
     uint256 public Sum; // total balance
+    uint256 public min; // minimum activation threshold [wad]
 
     event Fire();
     event Join(address indexed usr, uint256 wad);
+    event File(bytes32 indexed what, uint256 data);
 
     constructor(address gem_, address end_, address proxy_, uint256 min_) public {
         gem = GemLike(gem_);
@@ -55,7 +56,7 @@ contract ESM {
         min = min_;
     }
 
-    function revokesGovernanceAccess() external view returns (bool ret) {
+    function revokedGovernanceAccess() external view returns (bool ret) {
         ret = proxy != address(0);
     }
 
@@ -63,6 +64,19 @@ contract ESM {
     function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x + y;
         require(z >= x);
+    }
+
+    // -- admin --
+    function file(bytes32 what, uint256 data) external {
+        require(msg.sender == proxy, "ESM/not-authorized");
+        if (what == "min") {
+            require(data > 0, "ESM/min-required");
+            min = data;
+        } else {
+            revert("ESM/file-unrecognized-param");
+        }
+
+        emit File(what, data);
     }
 
     function fire() external {

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -38,13 +38,13 @@ interface DenyLike {
 }
 
 contract ESM {
-    mapping (address => uint256) public wards; // auth
-
     GemLike public immutable gem;   // collateral (MKR token)
     EndLike public immutable end;   // cage module
     address public immutable proxy; // Pause proxy
 
+    mapping(address => uint256) public wards; // auth
     mapping(address => uint256) public sum; // per-address balance
+    
     uint256 public Sum; // total balance
     uint256 public min; // minimum activation threshold [wad]
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -39,7 +39,6 @@ interface DenyLike {
 
 contract ESM {
     GemLike public immutable gem;   // collateral (MKR token)
-    EndLike public immutable end;   // cage module
     address public immutable proxy; // Pause proxy
 
     mapping(address => uint256) public wards; // auth
@@ -47,10 +46,12 @@ contract ESM {
     
     uint256 public Sum; // total balance
     uint256 public min; // minimum activation threshold [wad]
+    EndLike public end; // cage module
 
     event Fire();
     event Join(address indexed usr, uint256 wad);
     event File(bytes32 indexed what, uint256 data);
+    event File(bytes32 indexed what, address data);
     event Rely(address indexed usr);
     event Deny(address indexed usr);
 
@@ -95,6 +96,16 @@ contract ESM {
         if (what == "min") {
             require(data > 0, "ESM/min-required");
             min = data;
+        } else {
+            revert("ESM/file-unrecognized-param");
+        }
+
+        emit File(what, data);
+    }
+    
+    function file(bytes32 what, address data) external auth {
+        if (what == "end") {
+            end = EndLike(data);
         } else {
             revert("ESM/file-unrecognized-param");
         }

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -56,7 +56,7 @@ contract ESM {
         min = min_;
     }
 
-    function revokedGovernanceAccess() external view returns (bool ret) {
+    function revokesGovernanceAccess() external view returns (bool ret) {
         ret = proxy != address(0);
     }
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -73,7 +73,7 @@ contract ESM {
     }
 
     // --- Auth ---
-    mapping (address => uint) public wards;
+    mapping (address => uint256) public wards;
     function rely(address usr) external auth {
         wards[usr] = 1;
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -38,6 +38,8 @@ interface DenyLike {
 }
 
 contract ESM {
+    mapping (address => uint256) public wards; // auth
+
     GemLike public immutable gem;   // collateral (MKR token)
     EndLike public immutable end;   // cage module
     address public immutable proxy; // Pause proxy
@@ -73,7 +75,6 @@ contract ESM {
     }
 
     // --- Auth ---
-    mapping (address => uint256) public wards;
     function rely(address usr) external auth {
         wards[usr] = 1;
 

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -2,8 +2,7 @@
 
 /// ESM.sol
 
-// Copyright (C) 2019-2021 Maker Ecosystem Growth Holdings, INC.
-// Copyright (C) 2021-2022 Dai Foundation
+// Copyright (C) 2019-2022 Dai Foundation
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -146,10 +146,10 @@ contract ESMTest is DSTest {
         assertEq(address(esm.proxy()), pauseProxy);
         assertEq(esm.min(), 10_000 * WAD);
         assertEq(end.live(), 1);
-        assertTrue(esm.revokedGovernanceAccess());
+        assertTrue(esm.revokesGovernanceAccess());
 
         ESM esm2 = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
-        assertTrue(!esm2.revokedGovernanceAccess());
+        assertTrue(!esm2.revokesGovernanceAccess());
     }
 
     function test_Sum_is_internal_balance() public {

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -306,7 +306,7 @@ contract ESMTest is DSTest {
     }
 
     function test_file_new_min() public {
-        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("min", 20_000 * WAD);
@@ -316,11 +316,11 @@ contract ESMTest is DSTest {
 
     function test_file_new_min_then_fire() public {
         gem.mint(address(usr), 10_000 * WAD);
-        esm = new ESM(address(gem), address(end), address(this), 20_000 * WAD);
+        esm = new ESM(address(gem), address(end), pauseProxy, 20_000 * WAD);
         vat.rely(address(esm));
 
         assertEq(esm.min(), 20_000 * WAD);
-        assertEq(vat.wards(address(this)), 1);
+        assertEq(vat.wards(pauseProxy), 1);
 
         usr.callJoin(esm, 10_000 * WAD);
         esm.file("min", 10_000 * WAD);
@@ -329,12 +329,12 @@ contract ESMTest is DSTest {
 
         usr.callFire(esm);
 
-        assertEq(vat.wards(address(this)), 0);
+        assertEq(vat.wards(pauseProxy), 0);
         assertEq(end.live(), 0);
     }
 
     function testFail_file_revoked_gov() public {
-        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         esm.deny(address(this));
         assertEq(esm.min(), 10_000 * WAD);
 
@@ -349,14 +349,14 @@ contract ESMTest is DSTest {
     }
     
     function testFail_file_no_min() public {
-        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("min", 0);
     }
 
     function testFail_file_wrong_what() public {
-        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("wrong", 20_000 * WAD);

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -115,6 +115,9 @@ contract Authority {
 }
 
 contract ESMTest is DSTest {
+    
+    uint256 constant WAD = 10 ** 18;
+
     ESM     esm;
     DSToken gem;
     address pauseProxy = address(123);
@@ -135,22 +138,22 @@ contract ESMTest is DSTest {
     }
 
     function test_constructor() public {
-        esm = new ESM(address(gem), address(end), pauseProxy, 10);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
 
         assertEq(address(esm.gem()), address(gem));
         assertEq(address(esm.end()), address(end));
         assertEq(address(esm.proxy()), pauseProxy);
-        assertEq(esm.min(), 10);
+        assertEq(esm.min(), 10_000 * WAD);
         assertEq(end.live(), 1);
         assertTrue(esm.revokedGovernanceAccess());
 
-        ESM esm2 = new ESM(address(gem), address(end), address(0), 10);
+        ESM esm2 = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
         assertTrue(!esm2.revokedGovernanceAccess());
     }
 
     function test_Sum_is_internal_balance() public {
-        esm = new ESM(address(gem), address(end), address(0), 10);
-        gem.mint(address(esm), 10);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        gem.mint(address(esm), 10_000 * WAD);
 
         assertEq(esm.Sum(), 0);
     }
@@ -209,7 +212,7 @@ contract ESMTest is DSTest {
     }
 
     function testFail_deny_insufficient_mkr() public {
-        esm = new ESM(address(gem), address(end), pauseProxy, 10);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         vat.rely(address(esm));
         usr.callDeny(esm, address(vat));
     }
@@ -224,13 +227,13 @@ contract ESMTest is DSTest {
     function testFail_join_after_fired() public {
         esm = new ESM(address(gem), address(end), address(0), 0);
         usr.callFire(esm);
-        gem.mint(address(usr), 10);
+        gem.mint(address(usr), 10_000 * WAD);
 
-        usr.callJoin(esm, 10);
+        usr.callJoin(esm, 10_000 * WAD);
     }
 
     function testFail_fire_min_not_met() public {
-        esm = new ESM(address(gem), address(end), address(0), 10);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
         assertTrue(esm.Sum() <= esm.min());
 
         usr.callFire(esm);
@@ -238,91 +241,91 @@ contract ESMTest is DSTest {
 
     // -- user actions --
     function test_join_burn() public {
-        gem.mint(address(usr), 10);
-        esm = new ESM(address(gem), address(end), address(0), 10);
+        gem.mint(address(usr), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
 
-        usr.callJoin(esm, 6);
-        assertEq(esm.Sum(), 6);
-        assertEq(gem.balanceOf(address(esm)), 6);
-        assertEq(gem.balanceOf(address(usr)), 4);
+        usr.callJoin(esm, 6_000 * WAD);
+        assertEq(esm.Sum(), 6_000 * WAD);
+        assertEq(gem.balanceOf(address(esm)), 6_000 * WAD);
+        assertEq(gem.balanceOf(address(usr)), 4_000 * WAD);
 
         esm.burn();
-        assertEq(esm.Sum(), 6);
+        assertEq(esm.Sum(), 6_000 * WAD);
         assertEq(gem.balanceOf(address(esm)), 0);
-        assertEq(gem.balanceOf(address(usr)), 4);
+        assertEq(gem.balanceOf(address(usr)), 4_000 * WAD);
 
-        usr.callJoin(esm, 4);
-        assertEq(esm.Sum(), 10);
-        assertEq(gem.balanceOf(address(esm)), 4);
+        usr.callJoin(esm, 4_000 * WAD);
+        assertEq(esm.Sum(), 10_000 * WAD);
+        assertEq(gem.balanceOf(address(esm)), 4_000 * WAD);
         assertEq(gem.balanceOf(address(usr)), 0);
 
         esm.burn();
-        assertEq(esm.Sum(), 10);
+        assertEq(esm.Sum(), 10_000 * WAD);
         assertEq(gem.balanceOf(address(esm)), 0);
         assertEq(gem.balanceOf(address(usr)), 0);
     }
 
     function test_burn_before_fire() public {
-        gem.mint(address(usr), 10);
-        esm = new ESM(address(gem), address(end), address(0), 10);
-        usr.callJoin(esm, 10);
-        assertEq(gem.balanceOf(address(esm)), 10);
+        gem.mint(address(usr), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        usr.callJoin(esm, 10_000 * WAD);
+        assertEq(gem.balanceOf(address(esm)), 10_000 * WAD);
         usr.callBurn(esm);
         assertEq(gem.balanceOf(address(esm)), 0);
         usr.callFire(esm);
     }
 
     function test_burn_after_fire() public {
-        gem.mint(address(usr), 10);
-        esm = new ESM(address(gem), address(end), address(0), 10);
-        usr.callJoin(esm, 10);
-        assertEq(gem.balanceOf(address(esm)), 10);
+        gem.mint(address(usr), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        usr.callJoin(esm, 10_000 * WAD);
+        assertEq(gem.balanceOf(address(esm)), 10_000 * WAD);
         usr.callFire(esm);
         usr.callBurn(esm);
         assertEq(gem.balanceOf(address(esm)), 0);
     }
 
     function test_join_over_min() public {
-        gem.mint(address(usr), 20);
-        esm = new ESM(address(gem), address(end), address(0), 10);
+        gem.mint(address(usr), 20_000 * WAD);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
 
-        usr.callJoin(esm, 10);
-        usr.callJoin(esm, 10);
+        usr.callJoin(esm, 10_000 * WAD);
+        usr.callJoin(esm, 10_000 * WAD);
     }
 
     function testFail_join_insufficient_balance() public {
-        esm = new ESM(address(gem), address(end), address(0), 10);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
         assertEq(gem.balanceOf(address(usr)), 0);
 
-        usr.callJoin(esm, 10);
+        usr.callJoin(esm, 10_000 * WAD);
     }
 
     function test_file_new_min() public {
-        esm = new ESM(address(gem), address(end), address(this), 10);
-        assertEq(esm.min(), 10);
+        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        assertEq(esm.min(), 10_000 * WAD);
 
-        esm.file("min", 20);
+        esm.file("min", 20_000 * WAD);
 
-        assertEq(esm.min(), 20);
+        assertEq(esm.min(), 20_000 * WAD);
     }
 
     function testFail_file_revoked_gov() public {
-        esm = new ESM(address(gem), address(end), address(0), 10);
-        assertEq(esm.min(), 10);
+        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        assertEq(esm.min(), 10_000 * WAD);
 
-        esm.file("min", 20);
+        esm.file("min", 20_000 * WAD);
     }
 
     function testFail_file_not_gov() public {
-        esm = new ESM(address(gem), address(end), pauseProxy, 10);
-        assertEq(esm.min(), 10);
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
+        assertEq(esm.min(), 10_000 * WAD);
 
-        esm.file("min", 20);
+        esm.file("min", 20_000 * WAD);
     }
     
     function testFail_file_no_min() public {
-        esm = new ESM(address(gem), address(end), address(this), 10);
-        assertEq(esm.min(), 10);
+        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("min", 0);
     }

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -369,11 +369,11 @@ contract ESMTest is DSTest {
         usr.callFile(esm, "min", 20_000 * WAD);
     }
     
-    function testFail_file_no_min() public {
+    function testFail_file_min_too_small() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 
-        esm.file("min", 0);
+        esm.file("min", WAD);
     }
 
     function testFail_file_uint256_wrong_what() public {

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -309,6 +309,25 @@ contract ESMTest is DSTest {
         assertEq(esm.min(), 20_000 * WAD);
     }
 
+    function test_file_new_min_then_fire() public {
+        gem.mint(address(usr), 10_000 * WAD);
+        esm = new ESM(address(gem), address(end), address(this), 20_000 * WAD);
+        vat.rely(address(esm));
+
+        assertEq(esm.min(), 20_000 * WAD);
+        assertEq(vat.wards(address(this)), 1);
+
+        usr.callJoin(esm, 10_000 * WAD);
+        esm.file("min", 10_000 * WAD);
+
+        assertEq(esm.min(), 10_000 * WAD);
+
+        usr.callFire(esm);
+
+        assertEq(vat.wards(address(this)), 0);
+        assertEq(end.live(), 0);
+    }
+
     function testFail_file_revoked_gov() public {
         esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
@@ -328,5 +347,12 @@ contract ESMTest is DSTest {
         assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("min", 0);
+    }
+
+    function testFail_file_wrong_what() public {
+        esm = new ESM(address(gem), address(end), address(this), 10_000 * WAD);
+        assertEq(esm.min(), 10_000 * WAD);
+
+        esm.file("wrong", 20_000 * WAD);
     }
 }

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -142,10 +142,10 @@ contract ESMTest is DSTest {
         assertEq(address(esm.proxy()), pauseProxy);
         assertEq(esm.min(), 10);
         assertEq(end.live(), 1);
-        assertTrue(esm.revokesGovernanceAccess());
+        assertTrue(esm.revokedGovernanceAccess());
 
         ESM esm2 = new ESM(address(gem), address(end), address(0), 10);
-        assertTrue(!esm2.revokesGovernanceAccess());
+        assertTrue(!esm2.revokedGovernanceAccess());
     }
 
     function test_Sum_is_internal_balance() public {
@@ -295,5 +295,35 @@ contract ESMTest is DSTest {
         assertEq(gem.balanceOf(address(usr)), 0);
 
         usr.callJoin(esm, 10);
+    }
+
+    function test_file_new_min() public {
+        esm = new ESM(address(gem), address(end), address(this), 10);
+        assertEq(esm.min(), 10);
+
+        esm.file("min", 20);
+
+        assertEq(esm.min(), 20);
+    }
+
+    function testFail_file_revoked_gov() public {
+        esm = new ESM(address(gem), address(end), address(0), 10);
+        assertEq(esm.min(), 10);
+
+        esm.file("min", 20);
+    }
+
+    function testFail_file_not_gov() public {
+        esm = new ESM(address(gem), address(end), pauseProxy, 10);
+        assertEq(esm.min(), 10);
+
+        esm.file("min", 20);
+    }
+    
+    function testFail_file_no_min() public {
+        esm = new ESM(address(gem), address(end), address(this), 10);
+        assertEq(esm.min(), 10);
+
+        esm.file("min", 0);
     }
 }

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -344,10 +344,10 @@ contract ESMTest is DSTest {
     function test_file_relied_address() public {
         // This is the pattern we will follow for the deployer:
         // 1. deploy the contract
-        // 2. rely on the governance pause proxy
+        // 2. rely on the governance pause proxy (usr in this case)
         // 3. deny the deployer to revoke access
-        // Now the pause proxy should be able to file new mins
-        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
+        // Now the pause proxy (usr contract below) should be able to file new mins
+        esm = new ESM(address(gem), address(end), address(usr), 10_000 * WAD);
         esm.rely(address(usr));
         esm.deny(address(this));
 

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -333,7 +333,7 @@ contract ESMTest is DSTest {
         assertEq(end.live(), 0);
     }
 
-    function testFail_file_revoked_gov() public {
+    function testFail_file_after_denied() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         esm.deny(address(this));
         assertEq(esm.min(), 10_000 * WAD);
@@ -341,7 +341,24 @@ contract ESMTest is DSTest {
         esm.file("min", 20_000 * WAD);
     }
 
-    function testFail_file_not_gov() public {
+    function test_file_relied_address() public {
+        // This is the pattern we will follow for the deployer:
+        // 1. deploy the contract
+        // 2. rely on the governance pause proxy
+        // 3. deny the deployer to revoke access
+        // Now the pause proxy should be able to file new mins
+        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
+        esm.rely(address(usr));
+        esm.deny(address(this));
+
+        assertEq(esm.min(), 10_000 * WAD);
+
+        usr.callFile(esm, "min", 20_000 * WAD);
+
+        assertEq(esm.min(), 20_000 * WAD);
+    }
+
+    function testFail_file_not_relied() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -94,12 +94,16 @@ contract TestUsr {
         esm.fire();
     }
 
-    function callDeny(ESM esm, address target) external {
-        esm.deny(target);
+    function callDenyProxy(ESM esm, address target) external {
+        esm.denyProxy(target);
     }
 
     function callBurn(ESM esm) external {
         esm.burn();
+    }
+
+    function callFile(ESM esm, bytes32 what, uint256 data) external {
+        esm.file(what, data);
     }
 }
 
@@ -192,7 +196,7 @@ contract ESMTest is DSTest {
         assertEq(vat.wards(pauseProxy), 0);
         assertEq(vat.wards(address(someContract)), 1);
         assertEq(someContract.wards(pauseProxy), 1);
-        usr.callDeny(esm, address(someContract));
+        usr.callDenyProxy(esm, address(someContract));
         assertEq(vat.wards(pauseProxy), 0);
         assertEq(vat.wards(address(someContract)), 1);
         assertEq(someContract.wards(pauseProxy), 0);
@@ -204,7 +208,7 @@ contract ESMTest is DSTest {
         esm = new ESM(address(gem), address(end), pauseProxy, 0);
         vat.rely(address(esm));
         assertEq(vat.wards(pauseProxy), 1);
-        usr.callDeny(esm, address(vat));
+        usr.callDenyProxy(esm, address(vat));
         assertEq(vat.wards(pauseProxy), 0);
         usr.callFire(esm);
         assertEq(vat.wards(pauseProxy), 0);
@@ -215,7 +219,7 @@ contract ESMTest is DSTest {
     function testFail_deny_insufficient_mkr() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         vat.rely(address(esm));
-        usr.callDeny(esm, address(vat));
+        usr.callDenyProxy(esm, address(vat));
     }
 
     function testFail_fire_twice() public {
@@ -331,6 +335,7 @@ contract ESMTest is DSTest {
 
     function testFail_file_revoked_gov() public {
         esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
+        esm.deny(address(this));
         assertEq(esm.min(), 10_000 * WAD);
 
         esm.file("min", 20_000 * WAD);
@@ -340,7 +345,7 @@ contract ESMTest is DSTest {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
 
-        esm.file("min", 20_000 * WAD);
+        usr.callFile(esm, "min", 20_000 * WAD);
     }
     
     function testFail_file_no_min() public {


### PR DESCRIPTION
Governance has asked PE to increase the minimum required to trigger the ESM.  This requires redeploying the contract.  The downside of this is that any MKR balance/accounting is lost and the ESM address changes in addition to the cost/complexity of deploying new contracts.

This adds a file function that the proxy can change.

Since governance can always pass an executive to revoke the ESM's auth on the system, this should not increase any governance attach risk.  It would still allow deploying an ESM that the pause proxy is not auth'ed on (i.e. `revokedGovernanceAccess() -> false`) where the min could not be changed.