### PR TITLE
Deny proxy event

### DIFF
--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -37,7 +37,7 @@ interface DenyLike {
 }
 
 contract ESM {
-
+    
     uint256 constant WAD = 10 ** 18;
 
     GemLike public immutable gem;   // collateral (MKR token)
@@ -45,11 +45,10 @@ contract ESM {
 
     mapping(address => uint256) public wards; // auth
     mapping(address => uint256) public sum; // per-address balance
-
+    
     uint256 public Sum; // total balance
     uint256 public min; // minimum activation threshold [wad]
     EndLike public end; // cage module
-    uint256 public stopped;
 
     event Fire();
     event Join(address indexed usr, uint256 wad);
@@ -67,11 +66,6 @@ contract ESM {
 
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
-    }
-
-    modifier live() {
-        require(stopped == 0, "ESM/permanently-disabled");
-        _;
     }
 
     function revokesGovernanceAccess() external view returns (bool ret) {
@@ -111,7 +105,7 @@ contract ESM {
 
         emit File(what, data);
     }
-
+    
     function file(bytes32 what, address data) external auth {
         if (what == "end") {
             end = EndLike(data);
@@ -122,11 +116,7 @@ contract ESM {
         emit File(what, data);
     }
 
-    function stop() external auth {
-        stopped = 1;
-    }
-
-    function fire() external live {
+    function fire() external {
         require(Sum >= min,  "ESM/min-not-reached");
 
         if (proxy != address(0)) {
@@ -137,14 +127,14 @@ contract ESM {
         emit Fire();
     }
 
-    function denyProxy(address target) external live {
+    function denyProxy(address target) external {
         require(Sum >= min,  "ESM/min-not-reached");
 
         DenyLike(target).deny(proxy);
         emit DenyProxy(target, proxy);
     }
 
-    function join(uint256 wad) external live {
+    function join(uint256 wad) external {
         require(end.live() == 1, "ESM/system-already-shutdown");
 
         sum[msg.sender] = add(sum[msg.sender], wad);

--- a/src/ESM.sol
+++ b/src/ESM.sol
@@ -57,6 +57,7 @@ contract ESM {
     event File(bytes32 indexed what, address data);
     event Rely(address indexed usr);
     event Deny(address indexed usr);
+    event DenyProxy(address indexed base, address indexed pause);
 
     constructor(address gem_, address end_, address proxy_, uint256 min_) public {
         gem = GemLike(gem_);
@@ -140,6 +141,7 @@ contract ESM {
         require(Sum >= min,  "ESM/min-not-reached");
 
         DenyLike(target).deny(proxy);
+        emit DenyProxy(target, proxy);
     }
 
     function join(uint256 wad) external live {

--- a/src/ESM.t.sol
+++ b/src/ESM.t.sol
@@ -105,7 +105,7 @@ contract TestUsr {
     function callFile(ESM esm, bytes32 what, uint256 data) external {
         esm.file(what, data);
     }
-
+    
     function callFile(ESM esm, bytes32 what, address data) external {
         esm.file(what, data);
     }
@@ -124,7 +124,7 @@ contract Authority {
 }
 
 contract ESMTest is DSTest {
-
+    
     uint256 constant WAD = 10 ** 18;
 
     ESM     esm;
@@ -368,7 +368,7 @@ contract ESMTest is DSTest {
 
         usr.callFile(esm, "min", 20_000 * WAD);
     }
-
+    
     function testFail_file_min_too_small() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(esm.min(), 10_000 * WAD);
@@ -382,7 +382,7 @@ contract ESMTest is DSTest {
 
         esm.file("wrong", 20_000 * WAD);
     }
-
+    
     function test_file_new_end() public {
         esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
         assertEq(address(esm.end()), address(end));
@@ -416,46 +416,5 @@ contract ESMTest is DSTest {
         assertEq(address(esm.end()), address(end));
 
         esm.file("wrong", address(456));
-    }
-
-    function testStopped() public {
-
-        esm = new ESM(address(gem), address(end), pauseProxy, 10_000 * WAD);
-        assertEq(address(esm.end()), address(end));
-        assertEq(esm.stopped(), 0);
-
-        esm.stop();
-
-        assertEq(esm.stopped(), 1);
-    }
-
-    function testFailStoppedFire() public {
-
-        esm = new ESM(address(gem), address(end), address(0), 0);
-        assertEq(vat.wards(pauseProxy), 1);
-        esm.stop();
-        usr.callFire(esm); // fail here
-    }
-
-    function testFailStoppedDenyProxy() public {
-
-        esm = new ESM(address(gem), address(end), pauseProxy, 0);
-        AuthedContractMock someContract = new AuthedContractMock();
-        someContract.rely(pauseProxy);
-        someContract.rely(address(esm));
-        vat.rely(address(someContract));
-
-        esm.stop();
-
-        usr.callDenyProxy(esm, address(someContract)); // Fail here
-    }
-
-    function testFailStoppedJoin() public {
-        gem.mint(address(usr), 10_000 * WAD);
-        esm = new ESM(address(gem), address(end), address(0), 10_000 * WAD);
-
-        esm.stop();
-
-        usr.callJoin(esm, 6_000 * WAD); // Fail here
     }
 }


### PR DESCRIPTION
Added event to denyProxy suggested at https://github.com/makerdao/esm/pull/25#discussion_r792632400

Some of the core contracts do not emit a deny event when they are triggered, so this will emit an event whenever the pause proxy is denied from a base contract.